### PR TITLE
add a couple of math intrinsics

### DIFF
--- a/src/lang/built-in.lisp
+++ b/src/lang/built-in.lisp
@@ -9,6 +9,8 @@
         :cl-cuda.lang.type)
   (:export ;; Built-in functions
            :rsqrt
+           :__exp
+           :__divide
            :atomic-add
            :pointer
            :syncthreads
@@ -125,6 +127,14 @@
             ((double) double nil "sqrt"))
     floor  (((float) int   nil "floorf")
             ((double) int   nil "floor"))
+    ;; mathematical intrinsics
+    ;;
+    ;; If there is no double version, then fall back on a correct but
+    ;; slow implementation.
+    __exp    (((float) float nil "__expf")
+              ((double) double nil "exp"))
+    __divide (((float float) float nil "__fdividef")
+              ((double double) double t "/"))
     ;; atomic functions
     atomic-add (((int* int) int nil "atomicAdd"))
     ;; address-of operator

--- a/src/lang/lang.lisp
+++ b/src/lang/lang.lisp
@@ -83,6 +83,8 @@
 ;; exported from COMMON-LISP package
 (reexport-from :cl-cuda.lang.built-in
                :include '(:rsqrt
+                          :__exp
+                          :__divide
                           :atomic-add
                           :pointer
                           :syncthreads


### PR DESCRIPTION
__expf() and __fdividef() can be large performance gains. Compiling
with --use_fast_math is another option, but its effects are global.