### PR TITLE
Make it build on ASDF 3.3

### DIFF
--- a/cl-cuda-examples.asd
+++ b/cl-cuda-examples.asd
@@ -3,16 +3,11 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-(defpackage cl-cuda-examples-asd
-  (:use :cl :asdf))
-(in-package :cl-cuda-examples-asd)
-
-(defsystem cl-cuda-examples
+(defsystem "cl-cuda-examples"
   :author "Masayuki Takagi"
   :license "LLGPL"
-  :depends-on (:cl-cuda
-               :imago)
+  :depends-on ("cl-cuda"
+               "imago")
   :components ((:module "examples"
                 :components
                 ((:file "diffuse0")
@@ -21,5 +16,4 @@
                  (:file "vector-add")
                  (:file "defglobal")
                  (:file "sph")
-                 (:file "sph-cpu"))))
-  :perform (load-op :after (op c) (asdf:clear-system c)))
+                 (:file "sph-cpu")))))

--- a/cl-cuda-interop-examples.asd
+++ b/cl-cuda-interop-examples.asd
@@ -3,17 +3,11 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-(defpackage cl-cuda-interop-examples-asd
-  (:use :cl :asdf))
-(in-package :cl-cuda-interop-examples-asd)
-
-(defsystem cl-cuda-interop-examples
+(defsystem "cl-cuda-interop-examples"
   :author "Masayuki Takagi"
   :license "LLGPL"
-  :depends-on (:cl-cuda-interop)
+  :depends-on ("cl-cuda-interop")
   :components ((:module "interop/examples"
                 :serial t
                 :components
-                ((:file "nbody"))))
-  :perform (load-op :after (op c) (asdf:clear-system c)))
+                ((:file "nbody")))))

--- a/cl-cuda-interop-test.asd
+++ b/cl-cuda-interop-test.asd
@@ -3,18 +3,11 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-(defpackage cl-cuda-interop-test-asd
-  (:use :cl :asdf))
-(in-package :cl-cuda-interop-test-asd)
-
-(defsystem cl-cuda-interop-test
+(defsystem "cl-cuda-interop-test"
   :author "Masayuki Takagi"
   :license "LLGPL"
-  :depends-on (:cl-cuda-interop
-               :prove)
+  :depends-on ("cl-cuda-interop" "prove")
   :components ((:module "interop/t"
                 :serial t
                 :components
-                ((:file "cl-cuda-interop"))))
-  :perform (load-op :after (op c) (asdf:clear-system c)))
+                ((:file "cl-cuda-interop")))))

--- a/cl-cuda-interop.asd
+++ b/cl-cuda-interop.asd
@@ -3,15 +3,7 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(eval-when (:load-toplevel :execute)
-  (asdf:operate 'asdf:load-op 'cffi-grovel))
-
-(in-package :cl-user)
-(defpackage cl-cuda-interop-asd
-  (:use :cl :asdf))
-(in-package :cl-cuda-interop-asd)
-
-(defsystem cl-cuda-interop
+(defsystem "cl-cuda-interop"
   :version "0.1"
   :author "Masayuki Takagi"
   :license "LLGPL"
@@ -35,16 +27,5 @@
                    (:file "api")))
                  (:file "cl-cuda-interop"))))
   :description "Cl-cuda with OpenGL interoperability."
-  :long-description
-  #.(with-open-file (stream (merge-pathnames
-                             #p"README.markdown"
-                             (or *load-pathname* *compile-file-pathname*))
-                            :if-does-not-exist nil
-                            :direction :input)
-      (when stream
-        (let ((seq (make-array (file-length stream)
-                               :element-type 'character
-                               :fill-pointer t)))
-          (setf (fill-pointer seq) (read-sequence seq stream))
-          seq)))
-  :in-order-to ((test-op (load-op cl-cuda-interop-test))))
+  ;; :long-description #.(read-file-string (subpathname *load-pathname* "README.markdown"))
+  :in-order-to ((test-op (test-op "cl-cuda-interop-test"))))

--- a/cl-cuda-misc.asd
+++ b/cl-cuda-misc.asd
@@ -3,18 +3,12 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-(defpackage cl-cuda-misc-asd
-  (:use :cl :asdf))
-(in-package :cl-cuda-misc-asd)
-
-(defsystem cl-cuda-misc
+(defsystem "cl-cuda-misc"
   :author "Masayuki Takagi"
   :license "LLGPL"
-  :depends-on (:local-time :cl-emb)
+  :depends-on ("local-time" "cl-emb")
   :components ((:module "misc"
                 :serial t
                 :components
                 ((:file "package")
-                 (:file "convert-error-string"))))
-  :perform (load-op :after (op c) (asdf:clear-system c)))
+                 (:file "convert-error-string")))))

--- a/cl-cuda-test.asd
+++ b/cl-cuda-test.asd
@@ -3,16 +3,11 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-(defpackage cl-cuda-test-asd
-  (:use :cl :asdf))
-(in-package :cl-cuda-test-asd)
-
-(defsystem cl-cuda-test
+(defsystem "cl-cuda-test"
   :author "Masayuki Takagi"
   :license "LLGPL"
-  :depends-on (:cl-cuda
-               :prove)
+  :depends-on ("cl-cuda"
+               "prove")
   :components ((:module "t"
                 :serial t
                 :components
@@ -42,5 +37,4 @@
                   ((:file "kernel-manager")
                    (:file "memory")
                    (:file "defkernel")
-                   (:file "timer"))))))
-  :perform (load-op :after (op c) (asdf:clear-system c)))
+                   (:file "timer")))))))

--- a/cl-cuda.asd
+++ b/cl-cuda.asd
@@ -3,15 +3,11 @@
   Copyright (c) 2012 Masayuki Takagi (kamonama@gmail.com)
 |#
 
-(in-package :cl-user)
-
-(eval-when (:load-toplevel :execute)
-  (asdf:operate 'asdf:load-op 'cffi-grovel))
-
-(defpackage cl-cuda-asd
-  (:use :cl :asdf))
+(defpackage :cl-cuda-asd
+  (:use :cl :asdf :uiop))
 (in-package :cl-cuda-asd)
 
+(load-system "cffi-grovel")
 
 ;;;
 ;;; Cuda-grovel-file ASDF component
@@ -19,35 +15,23 @@
 
 (defclass cuda-grovel-file (cffi-grovel:grovel-file) ())
 
-(defmethod asdf:perform :around ((op cffi-grovel::process-op) (c cuda-grovel-file))
-  ;; Process a grovel file only when CUDA SDK is found.
-  (let ((sdk-not-found (symbol-value (intern "*SDK-NOT-FOUND*" "CL-CUDA.DRIVER-API"))))
-    (unless sdk-not-found
-      (call-next-method))))
-
-(defmethod asdf:perform :around ((op asdf:compile-op) (c cuda-grovel-file))
+(defmethod asdf:perform :around ((o operation) (c cuda-grovel-file))
   ;; Compile a grovel file only when CUDA SDK is found.
   (let ((sdk-not-found (symbol-value (intern "*SDK-NOT-FOUND*" "CL-CUDA.DRIVER-API"))))
-    (unless sdk-not-found
-      (call-next-method))))
-
-(defmethod asdf:perform :around ((op asdf:load-op) (c cuda-grovel-file))
-  ;; Load a grovel file only when CUDA SDK is found.
-  (let ((sdk-not-found (symbol-value (intern "*SDK-NOT-FOUND*" "CL-CUDA.DRIVER-API"))))
-    (unless sdk-not-found
-      (call-next-method))))
-
+    (if sdk-not-found
+        (asdf::mark-operation-done o c)
+        (call-next-method))))
 
 ;;;
 ;;; Cl-cuda system definition
 ;;;
 
-(defsystem cl-cuda
+(defsystem "cl-cuda"
   :version "0.1"
   :author "Masayuki Takagi"
   :license "LLGPL"
-  :depends-on (:cffi :alexandria :external-program :osicat
-               :cl-pattern :split-sequence :cl-reexport :cl-ppcre)
+  :depends-on ("cffi" "alexandria" "external-program" "osicat"
+               "cl-pattern" "split-sequence" "cl-reexport" "cl-ppcre")
   :components ((:module "src"
                 :serial t
                 :components
@@ -93,16 +77,5 @@
                    (:file "api")))
                  (:file "cl-cuda"))))
   :description "Cl-cuda is a library to use NVIDIA CUDA in Common Lisp programs."
-  :long-description
-  #.(with-open-file (stream (merge-pathnames
-                             #p"README.markdown"
-                             (or *load-pathname* *compile-file-pathname*))
-                            :if-does-not-exist nil
-                            :direction :input)
-      (when stream
-        (let ((seq (make-array (file-length stream)
-                               :element-type 'character
-                               :fill-pointer t)))
-          (setf (fill-pointer seq) (read-sequence seq stream))
-          seq)))
-  :in-order-to ((test-op (load-op cl-cuda-test))))
+  :long-description #.(read-file-string (subpathname *load-pathname* "README.markdown"))
+  :in-order-to ((test-op (test-op "cl-cuda-test"))))


### PR DESCRIPTION
Call mark-operation-done when skipping a grovel-file.

Stop calling clear-system in perform.

Cleanup the .asd files to modern recommended style.